### PR TITLE
Fix Deprecated

### DIFF
--- a/tcpdi.php
+++ b/tcpdi.php
@@ -626,7 +626,7 @@ class TCPDI extends FPDF_TPL {
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
+                foreach ($value[1] as $k => $v) {
                     $this->_straightOut($k . ' ');
                     $this->pdf_write_value($v);
                 }


### PR DESCRIPTION
PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in tcpdi.php on line 629